### PR TITLE
Fix when bower fails to install dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,6 +2,6 @@
   "name": "firebase-import",
   "private": true,
   "dependencies": {
-    "firebase": "firebase"
+    "firebase": "firebase#~v1.1.3"
   }
 }


### PR DESCRIPTION
Fix for error

```
bower validate      1.1.3 against git://github.com/firebase/firebase-bower.git#*
bower checkout      firebase-import#master
bower invalid-meta  firebase-import is missing "main" entry in bower.json
bower invalid-meta  firebase-import is missing "ignore" entry in bower.json
bower ENORESTARGET  Tag/branch firebase does not exist
```
